### PR TITLE
Convert floating division to integer division for cropping

### DIFF
--- a/data/img_utils.py
+++ b/data/img_utils.py
@@ -46,10 +46,10 @@ def crop(img, crop_size=512):
 
     width, height = img.size  # Get dimensions
 
-    left = (width - crop_width) / 2
-    top = (height - crop_height) / 2
-    right = (width + crop_width) / 2
-    bottom = (height + crop_height) / 2
+    left = (width - crop_width) // 2
+    top = (height - crop_height) // 2
+    right = (width + crop_width) // 2
+    bottom = (height + crop_height) // 2
 
     return img.crop((left, top, right, bottom))
 


### PR DESCRIPTION
Hello there,

I ran the "create_manip_data.py" and it gave me a "float instead of integer" error because in the crop function in img_utils.py the cropping box consists of floats. I just changed the float division "/" to integer division "//" and it worked smoothly.